### PR TITLE
Gather schema details from all nodes

### DIFF
--- a/validators/xml_schema.py
+++ b/validators/xml_schema.py
@@ -174,10 +174,12 @@ class XmlSchemaValidator(object):
                                                "Unable to validate")
         else:
             required_imports = {}
-            for prefix, ns in root.nsmap.iteritems():
-                schema_location = self.__imports.get(ns)
-                if schema_location:
-                    required_imports[ns] = schema_location
+            # visit all nodes and gather schemas
+            for elem in root.iter():
+                for prefix, ns in elem.nsmap.iteritems():
+                    schema_location = self.__imports.get(ns)
+                    if schema_location:
+                        required_imports[ns] = schema_location
 
         if not required_imports:
             return self._build_result_dict(False, "Unable to determine schemas "


### PR DESCRIPTION
This fixes validating against schemas that are included in child nodes,
and not defined in the root node.

Previously, the validator gathered schema details based only on the nsmap
for the root node.  Any namespace/schema dependencies defined in child
nodes are not discovered, so validation fails when it should not.

Example:

```
<STIX_Package (base ns/schema dependencies) >
   <Related_Packages>
       <Related_Package>
           <Package (additional child specific ns/schema dependencies) >
       </Related_Package>
   </Releated_Packages>
</STIX_Package>
```

Since only the nsmap of the root node is scanned to compile the schema
list, the child will fail to validate since its schemas will not be
available.
