### PR TITLE
Best Practice Validation of Timestamp Usage

### DIFF
--- a/examples/best_practice_invalid.xml
+++ b/examples/best_practice_invalid.xml
@@ -38,7 +38,7 @@
 	<stix:Indicators>
 		<stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-2e20c5b2-56fa-46cd-9662-8f199c69d2c9" timestamp="2014-02-20T09:00:00.000000Z" version="2.1.1">
 			<indicator:Title>Sample Domain Watchlist Indicator</indicator:Title>
-			<indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0”>Domain Watchlist</indicator:Type>
+			<indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0">Domain Watchlist</indicator:Type>
 			<indicator:Description>Sample domain Indicator for this watchlist</indicator:Description>
 			<indicator:Observable id="example:Observable-87c9a5bb-d005-4b3e-8081-99f720fad62b">
 				<cybox:Object id="example:Object-12c760ba-cd2c-4f5d-a37d-18212eac7928">
@@ -48,5 +48,18 @@
 				</cybox:Object>
 			</indicator:Observable>
 		</stix:Indicator>
+		<stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-2e20c5b2-56fa-46cd-9662-8f199c69d2d0" version="2.1.1">
+			<indicator:Title>Sample Domain Watchlist Indicator</indicator:Title>
+			<indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0">Domain Watchlist</indicator:Type>
+			<indicator:Description>Sample domain Indicator for this watchlist</indicator:Description>
+			<indicator:Observable id="example:Observable-87c9a5bb-d005-4b3e-8081-99f720fad73c">
+				<cybox:Object id="example:Object-12c760ba-cd2c-4f5d-a37d-18212eac7a39">
+					<cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType" type="FQDN">
+						<DomainNameObj:Value condition="Equals" apply_condition="ANY">malicious1.example.com##comma##malicious2.example.com##comma##malicious3.example.com</DomainNameObj:Value>
+					</cybox:Properties>
+				</cybox:Object>
+			</indicator:Observable>
+		</stix:Indicator>
+		<stix:Indicator xsi:type="indicator:IndicatorType" idref="example:Indicator-2e20c5b2-56fa-46cd-9662-8f199c69d2c9" timestamp="2014-02-20T10:00:00.000000Z" version="2.1.1" />
 	</stix:Indicators>
 </stix:STIX_Package>

--- a/sdv.py
+++ b/sdv.py
@@ -328,7 +328,7 @@ def _print_best_practice_results(fn, results):
             for node in marking_control_xpath_issues:
                 _print_level("[~] line: [%s]\tissue: %s", 2,
                             node['line_number'], node['problem'])
-        
+
         vocab_suggestions = warnings.get('vocab_suggestions')
         if vocab_suggestions:
             _print_level("[#] Vocab suggestions", 1)
@@ -337,6 +337,23 @@ def _print_best_practice_results(fn, results):
                             node['out_of_date'], node['line_number'],
                             node['given_version'],
                             node.get('newest_version', "???"))
+
+        invalid_idref_timestamp = warnings.get('invalid_idref_timestamp')
+        if invalid_idref_timestamp:
+            _print_level("[#] Element references a non-existent idref/timestamp combination", 1)
+            for node in invalid_idref_timestamp:
+                _print_level("[~] Element: [%s] line: [%s] idref: [%s] timestamp: [%s]", 2,
+                            node['tag'], node['line_number'],
+                            node['idref'],
+                            node['timestamp'])
+
+        id_timestamp_suggested = warnings.get('id_timestamp_suggested')
+        if id_timestamp_suggested:
+            _print_level("[#] Elements with IDs should also be timestamped", 1)
+            for node in id_timestamp_suggested:
+                _print_level("[~] Element: [%s] line: [%s] with ID: [%s]", 2,
+                            node['tag'], node['line_number'],
+                            node['id'])
 
 def _print_profile_results(fn, results):
     """Prints STIX Profile validation results to stdout.


### PR DESCRIPTION
Fixes #9.

XPath is run to ensure that all major ID-able elements have timestamps, and warns when elements do not have timestamps. In addition, elements with idrefs and timestamps are collated, and those idref/timestamp combos are used to ensure an element with that combination does exist. This check does not ensure that the referenced item is of a specific type though, as I wasn't sure that this is the right place for that (or that this is feasible to solve via generic XPath.)
