### PR TITLE
CybOX Validation

### DIFF
--- a/examples/best_practice_invalid.xml
+++ b/examples/best_practice_invalid.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <stix:STIX_Package
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:stix="http://stix.mitre.org/stix-1"

--- a/sdv/__init__.py
+++ b/sdv/__init__.py
@@ -35,7 +35,7 @@ def _load_sdv_mods():
         import sdv.validators as validators
 
 
-def validate_xml(doc, version=None, schemas=None, schemaloc=False):
+def validate_xml(doc, version=None, schemas=None, schemaloc=False, klass=None):
     """Performs `XML Schema`_ validation against a `STIX`_ or `CybOX`_ document.
 
     .. _STIX: http://stix.mitre.org/language/
@@ -76,7 +76,9 @@ def validate_xml(doc, version=None, schemas=None, schemaloc=False):
 
     """
     _load_sdv_mods()
-    klass = validators.get_xml_validator_class(doc)
+
+    # Get the validator class required to validate `doc`
+    klass = klass or validators.get_xml_validator_class(doc)
 
     try:
         validator = __xml_validators[klass][schemas]
@@ -159,3 +161,57 @@ def validate_profile(doc, profile):
         __profile_validators[profile] = validator
 
     return validator.validate(doc)
+
+
+def profile_to_xslt(profile):
+    """Converts the `STIX Profile`_ `profile` into an XSLT representation.
+
+    .. _STIX Profile: http://stixproject.github.io/documentation/profiles/
+
+    Args:
+        profile: A filename to a STIX Profile document.
+
+    Returns:
+         An ``etree._ElementTree`` XSLT representation of `profile`.
+
+    Raises:
+        .ProfileParseError: If an error occurred while attempting to
+            parse the `profile`.
+
+    """
+    _load_sdv_mods()
+
+    try:
+        validator = __profile_validators[profile]
+    except KeyError:
+        validator = validators.STIXProfileValidator(profile)
+        __profile_validators[profile] = validator
+
+    return validator.xslt
+
+
+def profile_to_schematron(profile):
+    """Converts the `STIX Profile`_ `profile` into a schematron representation.
+
+    .. _STIX Profile: http://stixproject.github.io/documentation/profiles/
+
+    Args:
+        profile: A filename to a STIX Profile document.
+
+    Returns:
+         An ``etree._ElementTree`` Schematron representation of `profile`.
+
+    Raises:
+        .ProfileParseError: If an error occurred while attempting to
+            parse the `profile`.
+
+    """
+    _load_sdv_mods()
+
+    try:
+        validator = __profile_validators[profile]
+    except KeyError:
+        validator = validators.STIXProfileValidator(profile)
+        __profile_validators[profile] = validator
+
+    return validator.schematron

--- a/sdv/__init__.py
+++ b/sdv/__init__.py
@@ -3,9 +3,11 @@
 
 # builtin
 import os
+import collections
 
 # internal
-from version import __version__
+from sdv import errors, utils
+from sdv.version import __version__
 
 # lazy imports
 validators = None
@@ -14,35 +16,38 @@ validators = None
 _PKG_DIR = os.path.dirname(__file__)
 XSD_ROOT = os.path.abspath(os.path.join(_PKG_DIR, 'xsd'))
 
-# A cache of STIX XML validators that speeds up consecutive calls to
+# A cache of STIX and CybOX XML validators that speeds up consecutive calls to
 # validate_xml() against non-bundled schema directories.
-__xml_validators = {}
+__xml_validators = collections.defaultdict(dict)
 
 # A cache of STIX Profile validators to speed up consecutive calls to
 # validate_profile()
 __profile_validators = {}
 
 
-def _load_validators_mod():
-    """Lazily load the sdv.validators module"""
+def _load_sdv_mods():
+    """Lazily load the sdv.validators modules. This is to prevent
+    circular imports while minimizing the performance overhead of imports.
 
+    """
     global validators
     if not validators:
         import sdv.validators as validators
 
 
 def validate_xml(doc, version=None, schemas=None, schemaloc=False):
-    """Performs `XML Schema`_ validation against a STIX document.
+    """Performs `XML Schema`_ validation against a `STIX`_ or `CybOX`_ document.
 
-    .. _XML Schema: http://stix.mitre.org/language/
+    .. _STIX: http://stix.mitre.org/language/
+    .. _CybOX: http://cybox.mitre.org/language/
 
     Args:
         doc: A STIX document to validate. This can be a filename, file-like
             object, ``etree._Element`` or ``etree._ElementTree`` object.
-        version: The version of the STIX document being validated. If ``None``
-            an attempt will be made to extract the version from `doc`.
-        schemas: A string path to a directory of STIX schemas. If ``None``,
-            the validation code will leverage its bundled STIX schemas.
+        version: The version of the STIX/CybOX document being validated. If
+            ``None`` an attempt will be made to extract the version from `doc`.
+        schemas: A string path to a directory of STIX/CybOX schemas. If ``None``,
+            the validation code will leverage its bundled STIX/CybOX schemas.
         schemaloc: Use ``xsi:schemaLocation`` attribute on `doc` to perform
             validation.
 
@@ -70,13 +75,14 @@ def validate_xml(doc, version=None, schemas=None, schemaloc=False):
             processing ``xs:include`` directives.
 
     """
-    _load_validators_mod()
+    _load_sdv_mods()
+    klass = validators.get_xml_validator_class(doc)
 
     try:
-        validator = __xml_validators[schemas]
+        validator = __xml_validators[klass][schemas]
     except KeyError:
-        validator = validators.STIXSchemaValidator(schema_dir=schemas)
-        __xml_validators[schemas] = validator
+        validator = klass(schema_dir=schemas)
+        __xml_validators[klass][schemas] = validator
 
     return validator.validate(doc, version=version, schemaloc=schemaloc)
 
@@ -108,7 +114,11 @@ def validate_best_practices(doc, version=None):
             in `doc` contains an invalid STIX version number.
 
     """
-    _load_validators_mod()
+    _load_sdv_mods()
+
+    if not utils.is_stix(doc):
+        raise errors.ValidationError("Input document is not a STIX document.")
+
     validator = validators.STIXBestPracticeValidator()
     return validator.validate(doc, version=version)
 
@@ -137,7 +147,10 @@ def validate_profile(doc, profile):
             parse the `profile`.
 
     """
-    _load_validators_mod()
+    _load_sdv_mods()
+
+    if not utils.is_stix(doc):
+        raise errors.ValidationError("Input document is not a STIX document.")
 
     try:
         validator = __profile_validators[profile]

--- a/sdv/__init__.py
+++ b/sdv/__init__.py
@@ -42,14 +42,17 @@ def validate_xml(doc, version=None, schemas=None, schemaloc=False, klass=None):
     .. _CybOX: http://cybox.mitre.org/language/
 
     Args:
-        doc: A STIX document to validate. This can be a filename, file-like
-            object, ``etree._Element`` or ``etree._ElementTree`` object.
+        doc: A STIX/CybOX document to validate. This can be a filename,
+            file-like object, ``etree._Element`` or ``etree._ElementTree``
+            object.
         version: The version of the STIX/CybOX document being validated. If
             ``None`` an attempt will be made to extract the version from `doc`.
         schemas: A string path to a directory of STIX/CybOX schemas. If ``None``,
             the validation code will leverage its bundled STIX/CybOX schemas.
         schemaloc: Use ``xsi:schemaLocation`` attribute on `doc` to perform
             validation.
+        klass: Internal use only. The validator klass to use for validating
+            `doc`.
 
     Note:
         The first time running this for a given `schemas` (or no `schemas`)
@@ -66,7 +69,7 @@ def validate_xml(doc, version=None, schemas=None, schemaloc=False, klass=None):
         .UnknownSTIXVersionError: If `version` is ``None`` and
             `doc` does not contain a ``@version`` attribute value.
         .InvalidSTIXVersionError: If `version` or the ``version``
-            attribute in `doc` contains an invalid STIX version number.
+            attribute in `doc` contains an invalid STIX/CybOX version number.
         .ValidationError: If the class was not initialized with a schema
                 directory and `schemaloc` is ``False``.
         .XMLSchemaImportError: If an error occurs while processing

--- a/sdv/errors.py
+++ b/sdv/errors.py
@@ -79,6 +79,33 @@ class InvalidSTIXVersionError(ValidationError):
         self.found = found
 
 
+class UnknownCyboxVersionError(ValidationError):
+    """Raised when no CybOX version information can be found in an instance
+    document and no version information was provided to a method which
+    requires version information.
+
+    """
+    pass
+
+
+class InvalidCyboxVersionError(ValidationError):
+    """Raised when an invalid version of CybOX is discovered within an instance
+    document or is passed into a method which depends on CybOX version
+    information.
+
+    Args:
+        message: The error message.
+        expected: A version or list of expected versions.
+        found: The CybOX version that was declared for an instance document or
+            found within an instance document.
+
+    """
+    def __init__(self, message, expected=None, found=None):
+        super(InvalidCyboxVersionError, self).__init__(message)
+        self.expected = expected
+        self.found = found
+
+
 class ProfileParseError(ValidationError):
     """Raised when an error occurs during the parse or initialization
     of a STIX profile document.

--- a/sdv/scripts/__init__.py
+++ b/sdv/scripts/__init__.py
@@ -1,0 +1,542 @@
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+# builtin
+import sys
+import json
+import collections
+
+# internal
+import sdv
+import sdv.codes as codes
+import sdv.utils as utils
+import sdv.validators as validators
+
+_QUIET = False
+
+class ValidationOptions(object):
+    """Collection of validation options which can be set via command line.
+
+    Attributes:
+        schema_validate: True if XML Schema validation should be performed.
+        schema_dir: A user-defined schema directory to validate against.
+        use_schemaloc: True if the XML Schema validation process should look
+            at the xsi:schemaLocation attribute to find schemas to validate
+            against.
+        lang_version: The version of STIX/CybOX which should be validated
+            against.
+        profile_validate: True if profile validation should be performed.
+        best_practice_validate: True if STIX best practice validation should
+            be performed.
+        profile_convert: True if a STIX Profile should be converted into
+            schematron or xslt.
+        xslt_out: The filename for the output profile xslt.
+        schematron_out: The filename for the output profile schematron.
+        json_results: True if results should be printed in JSON format.
+        quiet_output: True if only results and fatal errors should be printed
+            to stdout/stderr.
+        in_files: A list of input files and directories of files to be
+            validated.
+        in_profile: A filename/path for a STIX Profile to validate against or
+            convert.
+        recursive: Recursively descend into input directories.
+
+    """
+    def __init__(self):
+        # validation options
+        self.schema_validate = False
+        self.schema_dir = None
+        self.use_schemaloc = False
+        self.lang_version = None
+        self.profile_validate = False
+        self.best_practice_validate = False
+
+        # Classes
+        self.xml_validation_class = None
+        self.best_practice_validation_class = None
+        self.profile_validation_class = None
+
+        # conversion options
+        self.profile_convert = False
+        self.xslt_out = None
+        self.schematron_out = None
+
+        # output options
+        self.json_results = False
+        self.quiet_output = False
+
+        # input options
+        self.in_files = None
+        self.in_profile = None
+        self.recursive = False
+
+
+class ValidationResults(object):
+    """Stores validation results for given file.
+
+    Args:
+        fn: The filename/path for the file that was validated.
+
+    Attributes:
+        fn: The filename/path for the file that was validated.
+        schema_results: XML schema validation results.
+        best_practice_results: STIX Best Practice validation results.
+        profile_resutls: STIX Profile validation results.
+        fatal: Fatal error
+
+    """
+    def __init__(self, fn=None):
+        self.fn = fn
+        self.schema_results = None
+        self.best_practice_results = None
+        self.profile_results = None
+        self.fatal = None
+
+
+class ArgumentError(Exception):
+    """An exception to be raised when invalid or incompatible arguments are
+    passed into the application via the command line.
+
+    Args:
+        show_help (bool): If true, the help/usage information should be printed
+            to the screen.
+
+    Attributes:
+        show_help (bool): If true, the help/usage information should be printed
+            to the screen.
+
+    """
+    def __init__(self, msg=None, show_help=False):
+        super(ArgumentError, self).__init__(msg)
+        self.show_help = show_help
+
+
+class SchemaInvalidError(Exception):
+    """Exception to be raised when schema validation fails for a given
+    CybOX document.
+
+    Attributes:
+        results: An instance of sdv.validators.XmlValidationResults.
+
+    """
+    def __init__(self, msg=None, results=None):
+        super(SchemaInvalidError, self).__init__(msg)
+        self.results = results
+
+
+def set_output_level(options):
+    """Set the output level for the application.
+
+    If the ``quiet_output`` or ``json_results`` attributes are set on `options`
+    then the application does not print informational messages to stdout; only
+    results or fatal errors are printed to stdout.
+
+    """
+    global _QUIET
+    _QUIET = options.quiet_output or options.json_results
+
+
+def error(msg, status=codes.EXIT_FAILURE):
+    """Prints a message to the stderr prepended by '[!]' and calls
+    ```sys.exit(status)``.
+
+    Args:
+        msg: The error message to print.
+        status: The exit status code. Defaults to ``EXIT_FAILURE`` (1).
+
+    """
+    sys.stderr.write("[!] %s\n" % str(msg))
+    sys.exit(status)
+
+
+def info(msg):
+    """Prints a message to stdout, prepended by '[-]'.
+
+    Note:
+        If the application is running in "Quiet Mode"
+        (i.e., ``_QUIET == True``), this function will return
+        immediately and no message will be printed.
+
+    Args:
+        msg: The message to print.
+
+    """
+    if _QUIET:
+        return
+
+    print "[-] %s" % msg
+
+
+def print_level(fmt, level, *args):
+    """Prints a formatted message to stdout prepended by spaces. Useful for
+    printing hierarchical information, like bullet lists.
+
+    Args:
+        fmt (str): A Python formatted string.
+        level (int): Used to determing how many spaces to print. The formula
+            is ``'    ' * level ``.
+        *args: Variable length list of arguments. Values are plugged into the
+            format string.
+
+    Examples:
+        >>> print_level("%s %d", 0, "TEST", 0)
+        TEST 0
+        >>> print_level("%s %d", 1, "TEST", 1)
+            TEST 1
+        >>> print_level("%s %d", 2, "TEST", 2)
+                TEST 2
+
+    """
+    msg = fmt % args
+    spaces = '    ' * level
+    print "%s%s" % (spaces, msg)
+
+
+def print_fatal_results(results, level=0):
+    """Prints fatal errors that occurred during validation runs."""
+    print_level("[!] Fatal Error: %s", level, results.error)
+
+
+def print_schema_results(results, level=0):
+    """Prints XML Schema validation results to stdout.
+
+    Args:
+        results: An instance of sdv.validators.XmlSchemaResults.
+        level: The level to print the results.
+
+    """
+    marker = "+" if results.is_valid else "!"
+    print_level("[%s] XML Schema: %s", level, marker, results.is_valid)
+
+    if results.is_valid:
+        return
+
+    for error in results.errors:
+        print_level("[!] %s", level+1, error)
+
+
+def print_best_practice_results(results, level=0):
+    """Prints STIX Best Practice validation results to stdout.
+
+    Args:
+        results: An instance of sdv.validators.STIXBestPracticeResults
+        level: The level to print the results.
+
+    """
+    def print_warning(warning, level):
+        core_keys = warning.core_keys
+
+        # Print "core" values (e.g., id, idref, tag, etc.)
+        for key in (x for x in warning if x in core_keys):
+            print_level("[-] %s : %s", level, key, warning[key])
+
+        # Print "other" values (e.g., 'found version')
+        for key in (x for x in warning if x not in core_keys):
+            print_level("[-] %s : %s", level, key, warning[key])
+
+    def print_warnings(collection, level):
+        for warning in collection:
+            print_warning(warning, level)
+
+            # Print a divider if not the last warning
+            if warning is not collection[-1]:
+                print_level("-"*80, level)
+
+    marker = "+" if results.is_valid else "!"
+    print_level("[%s] Best Practices: %s", level, marker, results.is_valid)
+
+    if results.is_valid:
+        return
+
+    for collection in sorted(results, key=lambda x: x.name):
+        print_level("[!] %s", level+1, collection.name)
+        print_warnings(collection, level+2)
+
+
+def print_profile_results(results, level):
+    """Prints STIX Profile validation results to stdout.
+
+    Args:
+        results: An instance of sdv.validators.STIXProfileResults.
+        level: The level to print the results.
+
+    """
+    marker = "+" if results.is_valid else "!"
+    print_level("[%s] Profile: %s", level, marker, results.is_valid)
+
+    if results.is_valid:
+        return
+
+    errors_ = collections.defaultdict(list)
+    for e in results.errors:
+        errors_[e.message].append(e.line)
+
+    for msg, lines in errors_.iteritems():
+        print_level("[!] %s [%s]", level+1, msg, ', '.join(lines))
+
+
+def print_json_results(results):
+    """Prints `results` to stdout in JSON format.
+
+    Args:
+        results: An instance of ``ValidationResults`` which contains the
+            results to print.
+    """
+    json_results = {}
+    for fn, result in results.iteritems():
+        d = {}
+        if result.schema_results is not None:
+            d['schema validation'] = result.schema_results.as_dict()
+        if result.profile_results is not None:
+            d['profile results'] = result.profile_results.as_dict()
+        if result.best_practice_results is not None:
+            d['best practice results'] = result.best_practice_results.as_dict()
+        if result.fatal is not None:
+            d['fatal'] = result.fatal.as_dict()
+
+        json_results[fn] = d
+
+    print json.dumps(json_results)
+
+
+def print_results(results, options):
+    """Prints `results` to stdout. If ``options.json_output`` is set, the
+    results are printed in JSON format.
+
+    Args:
+        results: A dictionary of ValidationResults instances. The key is the
+            file path to the validated document.
+        options: An instance of ``ValidationOptions`` which contains output
+            options.
+
+    """
+    if options.json_results:
+        print_json_results(results)
+        return
+
+    level = 0
+    for fn, result in sorted(results.iteritems()):
+        print "=" * 80
+        print_level("[-] Results: %s", level, fn)
+
+        if result.schema_results is not None:
+            print_schema_results(result.schema_results, level)
+        if result.best_practice_results is not None:
+            print_best_practice_results(result.best_practice_results, level)
+        if result.profile_results is not None:
+            print_profile_results(result.profile_results, level)
+        if result.fatal is not None:
+            print_fatal_results(result.fatal, level)
+
+
+def convert_profile(options):
+    """Converts a STIX Profile to XSLT and/or Schematron formats.
+
+    This converts a STIX Profile document and writes the results to output
+    schematron and/or xslt files to the output file names.
+
+    The output file names are defined by
+    ``output.xslt_out`` and ``options.schematron_out``.
+
+    Args:
+        validator: An instance of STIXProfileValidator
+        options: ValidationOptions instance with validation options for this
+            validation run.
+
+    """
+    profile = options.in_profile
+    xslt_out_fn = options.xslt_out
+    schematron_out_fn = options.schematron_out
+
+    if schematron_out_fn:
+        info(
+            "Writing schematron conversion of profile to %s" %
+            schematron_out_fn
+        )
+
+        schematron = sdv.profile_to_schematron(profile)
+        schematron.write(
+            schematron_out_fn,
+            pretty_print=True,
+            xml_declaration=True,
+            encoding="UTF-8"
+        )
+
+    if xslt_out_fn:
+        info("Writing xslt conversion of profile to %s" % xslt_out_fn)
+
+        xslt = sdv.profile_to_xslt(profile)
+        xslt.write(
+            xslt_out_fn,
+            pretty_print=True,
+            xml_declaration=True,
+            encoding="UTF-8"
+        )
+
+
+def profile_validate(fn, options):
+    """Performs STIX Profile validation against the input filename.
+    Args:
+        fn: A filename for a STIX document
+    Returns:
+        A dictionary of validation results
+    """
+    info("Performing profile validation on %s" % fn)
+
+    results = sdv.validate_profile(
+        fn,
+        profile=options.in_profile
+    )
+
+    return results
+
+
+def schema_validate(fn, options):
+    """Performs STIX/CybOX XML Schema validation against the input filename.
+
+    Args:
+        fn: A filename for a STIX/CybOX XML document
+        options: ValidationOptions instance with validation options for this
+            validation run.
+
+    Returns:
+        A dictionary of validation results
+
+    """
+    info("Performing xml schema validation on %s" % fn)
+
+    results = sdv.validate_xml(
+        fn,
+        version=options.lang_version,
+        schemas=options.schema_dir,
+        schemaloc=options.use_schemaloc,
+        klass=options.xml_validation_class
+    )
+
+    if not results.is_valid:
+        raise SchemaInvalidError(results=results)
+
+    return results
+
+
+def best_practice_validate(fn, options):
+    """Performs STIX Best Practice validation against the input filename.
+
+    Args:
+        validator: An instance of STIXBestPracticeValidator
+        fn: A filename for a STIX document
+        options: ValidationOptions instance with validation options for
+            this validation run.
+
+    Returns:
+        A dictionary of validation results
+
+    """
+    info("Performing best practice validation on %s" % fn)
+
+    results = sdv.validate_best_practices(
+        fn,
+        version=options.lang_version
+    )
+
+    return results
+
+
+def validate_file(fn, options):
+    """Validates the input document `fn` with the validators that are passed
+    in.
+
+    Profile and/or Best Practice validation will only occur if `fn` is
+    schema-valid.
+
+    If any exceptions are raised during validation, no further validation
+    will take place.
+
+    Args:
+        schema_validator: An instance of STIXSchemaValidator (optional)
+        profile_validator: An instance of STIXProfileValidator (optional)
+        best_practice_validator: An instance of STIXBestPracticeValidator
+            (optional).
+        options: An instance of ValidationOptions.
+
+    Returns:
+        An instance of ValidationResults.
+
+    """
+    results = ValidationResults(fn)
+
+    try:
+        if options.schema_validate:
+            results.schema_results = schema_validate(fn, options)
+        if options.best_practice_validate:
+            results.best_practice_results = best_practice_validate(fn, options)
+        if options.profile_validate:
+            results.profile_results = profile_validate(fn, options)
+    except SchemaInvalidError as ex:
+        results.schema_results = ex.results
+        if options.profile_validate or options.best_practice_validate:
+            msg = (
+                "File '{0}' was schema-invalid. No further validation will be "
+                "performed."
+            )
+            msg = msg.format(fn)
+            info(msg)
+
+    except Exception as ex:
+        results.fatal = validators.ValidationErrorResults(ex)
+        msg = (
+            "Unexpected error occurred with file '{0}'. No further validation "
+            "will be performed: {1}"
+        )
+        msg = msg.format(fn, str(ex))
+        info(msg)
+
+    return results
+
+
+def run_validation(options):
+    """Validates files based on command line options.
+
+    Args:
+        options: An instance of ``ValidationOptions`` containing options for
+            this validation run.
+
+    """
+    files = utils.get_xml_files(options.in_files, options.recursive)
+    results = {}
+
+    for fn in files:
+        results[fn] = validate_file(fn, options)
+
+    if options.profile_convert:
+        convert_profile(options)
+
+    return results
+
+
+def status_code(results):
+    """Determines the exit status code to be returned from this script
+    by inspecting the results returned from validating file(s).
+
+    Status codes are binary OR'd together, so exit codes can communicate
+    multiple error conditions.
+
+    """
+    status = codes.EXIT_SUCCESS
+
+    for result in results.itervalues():
+        schema = result.schema_results
+        best_practice = result.best_practice_results
+        profile = result.profile_results
+        fatal = result.fatal
+
+        if schema and not schema.is_valid:
+            status |= codes.EXIT_SCHEMA_INVALID
+        if best_practice and not best_practice.is_valid:
+            status |= codes.EXIT_BEST_PRACTICE_INVALID
+        if profile and not profile.is_valid:
+            status |= codes.EXIT_PROFILE_INVALID
+        if fatal:
+            status |= codes.EXIT_VALIDATION_ERROR
+
+    return status

--- a/sdv/scripts/cybox_validator.py
+++ b/sdv/scripts/cybox_validator.py
@@ -22,313 +22,17 @@ Attributes:
         printed.
 
 """
+# builtin
 import sys
-import json
 import logging
 import argparse
 
+# internal
 import sdv
 import sdv.codes as codes
-import sdv.utils as utils
 import sdv.errors as errors
+import sdv.scripts as scripts
 import sdv.validators as validators
-
-# Only print results and/or system errors.
-quiet = False
-
-class ValidationOptions(object):
-    """Collection of validation options which can be set via command line.
-
-    Attributes:
-        schema_validate: True if XML Schema validation should be performed.
-        schema_dir: A user-defined schema directory to validate against.
-        use_schemaloc: True if the XML Schema validation process should look
-            at the xsi:schemaLocation attribute to find schemas to validate
-            against.
-        cybox_version: The version of CybOX which should be validated against.
-        json_results: True if results should be printed in JSON format.
-        quiet_output: True if only results and fatal errors should be printed
-            to stdout/stderr.
-        in_files: A list of input files and directories of files to be
-            validated.
-        recursive: Recursively descend into input directories.
-
-    """
-    def __init__(self):
-        # validation options
-        self.schema_validate = False
-        self.schema_dir = None
-        self.use_schemaloc = False
-        self.cybox_version = None
-
-        # output options
-        self.json_results = False
-        self.quiet_output = False
-
-        # input options
-        self.in_files = None
-        self.recursive = False
-
-
-class ValidationResults(object):
-    """Stores validation results for given file.
-
-    Args:
-        fn: The filename/path for the file that was validated.
-
-    Attributes:
-        fn: The filename/path for the file that was validated.
-        schema_results: XML schema validation results.
-        fatal: Fatal error
-
-    """
-    def __init__(self, fn=None):
-        self.fn = fn
-        self.schema_results = None
-        self.fatal = None
-
-
-class ArgumentError(Exception):
-    """An exception to be raised when invalid or incompatible arguments are
-    passed into the application via the command line.
-
-    Args:
-        show_help (bool): If true, the help/usage information should be printed
-            to the screen.
-
-    Attributes:
-        show_help (bool): If true, the help/usage information should be printed
-            to the screen.
-
-    """
-    def __init__(self, msg=None, show_help=False):
-        super(ArgumentError, self).__init__(msg)
-        self.show_help = show_help
-
-
-class SchemaInvalidError(Exception):
-    """Exception to be raised when schema validation fails for a given
-    CybOX document.
-
-    Attributes:
-        results: An instance of sdv.validators.XmlValidationResults.
-
-    """
-    def __init__(self, msg=None, results=None):
-        super(SchemaInvalidError, self).__init__(msg)
-        self.results = results
-
-
-def _error(msg, status=codes.EXIT_FAILURE):
-    """Prints a message to the stderr prepended by '[!]' and calls
-    ```sys.exit(status)``.
-
-    Args:
-        msg: The error message to print.
-        status: The exit status code. Defaults to ``EXIT_FAILURE`` (1).
-
-    """
-    sys.stderr.write("[!] %s\n" % str(msg))
-    sys.exit(status)
-
-
-def _info(msg):
-    """Prints a message to stdout, prepended by '[-]'.
-
-    Note:
-        If the application is running in "Quiet Mode"
-        (i.e., ``quiet == True``), this function will return
-        immediately and no message will be printed.
-
-    Args:
-        msg: The message to print.
-
-    """
-    if quiet:
-        return
-
-    print "[-] %s" % msg
-
-
-def _print_level(fmt, level, *args):
-    """Prints a formatted message to stdout prepended by spaces. Useful for
-    printing hierarchical information, like bullet lists.
-
-    Args:
-        fmt (str): A Python formatted string.
-        level (int): Used to determing how many spaces to print. The formula
-            is ``'    ' * level ``.
-        *args: Variable length list of arguments. Values are plugged into the
-            format string.
-
-    Examples:
-        >>> _print_level("%s %d", 0, "TEST", 0)
-        TEST 0
-        >>> _print_level("%s %d", 1, "TEST", 1)
-            TEST 1
-        >>> _print_level("%s %d", 2, "TEST", 2)
-                TEST 2
-
-    """
-    msg = fmt % args
-    spaces = '    ' * level
-    print "%s%s" % (spaces, msg)
-
-
-def _set_output_level(options):
-    """Set the output level for the application.
-
-    If the ``quiet_output`` or ``json_results`` attributes are set on `options`
-    then the application does not print informational messages to stdout; only
-    results or fatal errors are printed to stdout.
-
-    """
-    global quiet
-    quiet = options.quiet_output or options.json_results
-
-
-def _print_fatal_results(results, level=0):
-    """Prints fatal errors that occurred during validation runs."""
-    _print_level("[!] Fatal Error: %s", level, results.error)
-
-
-def _print_schema_results(results, level=0):
-    """Prints CybOX Schema validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.XmlSchemaResults.
-        level: The level to print the results.
-
-    """
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] XML Schema: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    for error in results.errors:
-        _print_level("[!] %s", level+1, error)
-
-
-def _print_json_results(results):
-    """Prints `results` to stdout in JSON format.
-
-    Args:
-        results: An instance of ``ValidationResults`` which contains the
-            results to print.
-
-    """
-    json_results = {}
-    for fn, result in results.iteritems():
-        d = {}
-        if result.schema_results is not None:
-            d['schema validation'] = result.schema_results.as_dict()
-        if result.fatal is not None:
-            d['fatal'] = result.fatal.as_dict()
-
-        json_results[fn] = d
-
-    print json.dumps(json_results)
-
-
-def _print_results(results, options):
-    """Prints `results` to stdout. If ``options.json_output`` is set, the
-    results are printed in JSON format.
-
-    Args:
-        results: A dictionary of ValidationResults instances. The key is the
-            file path to the validated document.
-        options: An instance of ``ValidationOptions`` which contains output
-            options.
-
-    """
-    if options.json_results:
-        _print_json_results(results)
-        return
-
-    level = 0
-    for fn, result in sorted(results.iteritems()):
-        print "=" * 80
-        _print_level("[-] Results: %s", level, fn)
-
-        if result.schema_results is not None:
-            _print_schema_results(result.schema_results, level)
-        if result.fatal is not None:
-            _print_fatal_results(result.fatal, level)
-
-
-def _schema_validate(validator, fn, options):
-    """Performs CybOX XML Schema validation against the input filename.
-
-    Args:
-        validator: An instance of validators.CybOXSchemaValidator
-        fn: A filename for a CybOX document
-        options: ValidationOptions instance with validation options for this
-            validation run.
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing xml schema validation on %s" % fn)
-
-    results = validator.validate(
-        fn,
-        version=options.cybox_version,
-        schemaloc=options.use_schemaloc
-    )
-
-    if not results.is_valid:
-        raise SchemaInvalidError(results=results)
-
-    return results
-
-
-def _validate_file(fn, options, schema_validator):
-    """Validates the input document `fn` with the validators that are passed
-    in.
-
-    If any exceptions are raised during validation, no further validation
-    will take place.
-
-    Args:
-        schema_validator: An instance of CybOXSchemaValidator (optional)
-        options: An instance of ValidationOptions.
-
-    Returns:
-        An instance of ValidationResults.
-
-    """
-    results = ValidationResults(fn)
-
-    try:
-        results.schema_results = _schema_validate(schema_validator, fn, options)
-    except SchemaInvalidError as ex:
-        results.schema_results = ex.results
-    except Exception as ex:
-        results.fatal = validators.ValidationErrorResults(ex)
-        _info("Unexpected error occurred with file %s: %s" % (fn, str(ex)))
-
-    return results
-
-
-def _validate(options):
-    """Validates files based on command line options.
-
-    Args:
-        options: An instance of ``ValidationOptions`` containing options for
-            this validation run.
-
-    """
-    files = utils.get_xml_files(options.in_files, options.recursive)
-    schema_validator = validators.CyboxSchemaValidator(schema_dir=options.schema_dir)
-
-    results = {}
-    for fn in files:
-        result = _validate_file(fn, options, schema_validator=schema_validator)
-        results[fn] = result
-
-    return results
 
 
 def _set_validation_options(args):
@@ -342,13 +46,13 @@ def _set_validation_options(args):
         Instance of ``ValidationOptions``.
 
     """
-    options = ValidationOptions()
+    options = scripts.ValidationOptions()
 
     if (args.files):
         options.schema_validate = True
 
     # input options
-    options.cybox_version = args.cybox_version
+    options.lang_version = args.lang_version
     options.schema_dir = args.schema_dir
     options.in_files = args.files
     options.recursive = args.recursive
@@ -356,6 +60,9 @@ def _set_validation_options(args):
     # output options
     options.json_results = args.json
     options.quiet_output = args.quiet
+
+    # class options
+    options.xml_validation_class = validators.CyboxSchemaValidator
 
     return options
 
@@ -374,10 +81,10 @@ def _validate_args(args):
 
     """
     if len(sys.argv) == 1:
-        raise ArgumentError("Invalid arguments", show_help=True)
+        raise scripts.ArgumentError("Invalid arguments", show_help=True)
 
-    if args.cybox_version and args.use_schemaloc:
-        raise ArgumentError(
+    if args.lang_version and args.use_schemaloc:
+        raise scripts.ArgumentError(
             "Cannot set both --cybox-version and --use-schemalocs"
         )
 
@@ -396,7 +103,7 @@ def _get_arg_parser():
 
     parser.add_argument(
         "--cybox-version",
-        dest="cybox_version",
+        dest="lang_version",
         default=None,
         help="The version of CybOX to validate against"
     )
@@ -452,28 +159,6 @@ def _get_arg_parser():
     return parser
 
 
-def _status_code(results):
-    """Determines the exit status code to be returned from this script
-    by inspecting the results returned from validating file(s).
-
-    Status codes are binary OR'd together, so exit codes can communicate
-    multiple error conditions.
-
-    """
-    status = codes.EXIT_SUCCESS
-
-    for result in results.itervalues():
-        schema = result.schema_results
-        fatal = result.fatal
-
-        if schema and not schema.is_valid:
-            status |= codes.EXIT_SCHEMA_INVALID
-        if fatal:
-            status |= codes.EXIT_VALIDATION_ERROR
-
-    sys.exit(status)
-
-
 def main():
     """Entry point for sdv.py.
 
@@ -496,24 +181,24 @@ def main():
         options = _set_validation_options(args)
 
         # Set the output level (e.g., quiet vs. verbose)
-        _set_output_level(options)
+        scripts.set_output_level(options)
 
         # Validate input documents
-        results = _validate(options)
+        results = scripts.run_validation(options)
 
         # Print validation results
-        _print_results(results, options)
+        scripts.print_results(results, options)
 
         # Determine exit status code and exit.
-        code = _status_code(results)
+        code = scripts.status_code(results)
         sys.exit(code)
 
-    except ArgumentError as ex:
+    except scripts.ArgumentError as ex:
         if ex.show_help:
             parser.print_help()
-        _error(ex)
+        scripts.error(ex)
     except (errors.ValidationError, IOError) as ex:
-        _error(
+        scripts.error(
             "Validation error occurred: '%s'" % str(ex),
             codes.EXIT_VALIDATION_ERROR
         )

--- a/sdv/scripts/cybox_validator.py
+++ b/sdv/scripts/cybox_validator.py
@@ -3,14 +3,7 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-"""STIX Document Validator - validates STIX instance documents.
-
-The STIX Document Validator can perform the following forms of STIX document
-validator:
-
-* STIX XML Schema validation
-* STIX Profile validation
-* STIX Best Practice validation
+"""CybOX Document Validator - validates CybOX XML instance documents.
 
 This script uses different exit status codes to indicate various forms of
 errors that can occur during validation. Because validation errors are
@@ -20,8 +13,6 @@ occurred at a glance:
 * ``0x0``. No errors occurred.
 * ``0x1``. A fatal system error occurred.
 * ``0x2``. At least one schema-invalid document was processed.
-* ``0x4``. At least one profile-invalid document was processed.
-* ``0x8``. At least on best-practice-invalid document was processed.
 * ``0x10``. A non-fatal error occurred during validation. This usually
   indicates scenarios where malformed XML documents are validated or missing
   files are attempted to be validated.
@@ -32,15 +23,14 @@ Attributes:
 
 """
 import sys
-import logging
-import collections
-import argparse
 import json
+import logging
+import argparse
 
 import sdv
 import sdv.codes as codes
-import sdv.errors as errors
 import sdv.utils as utils
+import sdv.errors as errors
 import sdv.validators as validators
 
 # Only print results and/or system errors.
@@ -55,21 +45,12 @@ class ValidationOptions(object):
         use_schemaloc: True if the XML Schema validation process should look
             at the xsi:schemaLocation attribute to find schemas to validate
             against.
-        stix_version: The version of STIX which should be validated against.
-        profile_validate: True if profile validation should be performed.
-        best_practice_validate: True if STIX best practice validation should
-            be performed.
-        profile_convert: True if a STIX Profile should be converted into
-            schematron or xslt.
-        xslt_out: The filename for the output profile xslt.
-        schematron_out: The filename for the output profile schematron.
+        cybox_version: The version of CybOX which should be validated against.
         json_results: True if results should be printed in JSON format.
         quiet_output: True if only results and fatal errors should be printed
             to stdout/stderr.
         in_files: A list of input files and directories of files to be
             validated.
-        in_profile: A filename/path for a STIX Profile to validate against or
-            convert.
         recursive: Recursively descend into input directories.
 
     """
@@ -78,14 +59,7 @@ class ValidationOptions(object):
         self.schema_validate = False
         self.schema_dir = None
         self.use_schemaloc = False
-        self.stix_version = None
-        self.profile_validate = False
-        self.best_practice_validate = False
-
-        # conversion options
-        self.profile_convert = False
-        self.xslt_out = None
-        self.schematron_out = None
+        self.cybox_version = None
 
         # output options
         self.json_results = False
@@ -93,7 +67,6 @@ class ValidationOptions(object):
 
         # input options
         self.in_files = None
-        self.in_profile = None
         self.recursive = False
 
 
@@ -106,16 +79,12 @@ class ValidationResults(object):
     Attributes:
         fn: The filename/path for the file that was validated.
         schema_results: XML schema validation results.
-        best_practice_results: STIX Best Practice validation results.
-        profile_resutls: STIX Profile validation results.
         fatal: Fatal error
 
     """
     def __init__(self, fn=None):
         self.fn = fn
         self.schema_results = None
-        self.best_practice_results = None
-        self.profile_results = None
         self.fatal = None
 
 
@@ -139,7 +108,7 @@ class ArgumentError(Exception):
 
 class SchemaInvalidError(Exception):
     """Exception to be raised when schema validation fails for a given
-    STIX document.
+    CybOX document.
 
     Attributes:
         results: An instance of sdv.validators.XmlValidationResults.
@@ -224,7 +193,7 @@ def _print_fatal_results(results, level=0):
 
 
 def _print_schema_results(results, level=0):
-    """Prints STIX Schema validation results to stdout.
+    """Prints CybOX Schema validation results to stdout.
 
     Args:
         results: An instance of sdv.validators.XmlSchemaResults.
@@ -241,82 +210,19 @@ def _print_schema_results(results, level=0):
         _print_level("[!] %s", level+1, error)
 
 
-def _print_best_practice_results(results, level=0):
-    """Prints STIX Best Practice validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.STIXBestPracticeResults
-        level: The level to print the results.
-
-    """
-    def _print_warning(warning, level):
-        core_keys = warning.core_keys
-
-        # Print "core" values (e.g., id, idref, tag, etc.)
-        for key in (x for x in warning if x in core_keys):
-            _print_level("[-] %s : %s", level, key, warning[key])
-
-        # Print "other" values (e.g., 'found version')
-        for key in (x for x in warning if x not in core_keys):
-            _print_level("[-] %s : %s", level, key, warning[key])
-
-    def _print_warnings(collection, level):
-        for warning in collection:
-            _print_warning(warning, level)
-
-            # Print a divider if not the last warning
-            if warning is not collection[-1]:
-                _print_level("-"*80, level)
-
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] Best Practices: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    for collection in sorted(results, key=lambda x: x.name):
-        _print_level("[!] %s", level+1, collection.name)
-        _print_warnings(collection, level+2)
-
-
-def _print_profile_results(results, level):
-    """Prints STIX Profile validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.STIXProfileResults.
-        level: The level to print the results.
-
-    """
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] Profile: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    errors_ = collections.defaultdict(list)
-    for e in results.errors:
-        errors_[e.message].append(e.line)
-
-    for msg, lines in errors_.iteritems():
-        _print_level("[!] %s [%s]", level+1, msg, ', '.join(lines))
-
-
 def _print_json_results(results):
     """Prints `results` to stdout in JSON format.
 
     Args:
         results: An instance of ``ValidationResults`` which contains the
             results to print.
+
     """
     json_results = {}
     for fn, result in results.iteritems():
         d = {}
         if result.schema_results is not None:
             d['schema validation'] = result.schema_results.as_dict()
-        if result.profile_results is not None:
-            d['profile results'] = result.profile_results.as_dict()
-        if result.best_practice_results is not None:
-            d['best practice results'] = result.best_practice_results.as_dict()
         if result.fatal is not None:
             d['fatal'] = result.fatal.as_dict()
 
@@ -347,63 +253,16 @@ def _print_results(results, options):
 
         if result.schema_results is not None:
             _print_schema_results(result.schema_results, level)
-        if result.best_practice_results is not None:
-            _print_best_practice_results(result.best_practice_results, level)
-        if result.profile_results is not None:
-            _print_profile_results(result.profile_results, level)
         if result.fatal is not None:
             _print_fatal_results(result.fatal, level)
 
 
-def _convert_profile(validator, options):
-    """Converts a STIX Profile to XSLT and/or Schematron formats.
-
-    This converts a STIX Profile document and writes the results to output
-    schematron and/or xslt files to the output file names.
-
-    The output file names are defined by
-    ``output.xslt_out`` and ``options.schematron_out``.
-
-    Args:
-        validator: An instance of STIXProfileValidator
-        options: ValidationOptions instance with validation options for this
-            validation run.
-
-    """
-    xslt = validator.xslt
-    xslt_out_fn = options.xslt_out
-    schematron = validator.schematron
-    schematron_out_fn = options.schematron_out
-
-    if schematron_out_fn:
-        _info(
-            "Writing schematron conversion of profile to %s" %
-            schematron_out_fn
-        )
-
-        schematron.write(
-            schematron_out_fn,
-            pretty_print=True,
-            xml_declaration=True,
-            encoding="UTF-8"
-        )
-
-    if xslt_out_fn:
-        _info("Writing xslt conversion of profile to %s" % xslt_out_fn)
-        xslt.write(
-            xslt_out_fn,
-            pretty_print=True,
-            xml_declaration=True,
-            encoding="UTF-8"
-        )
-
-
 def _schema_validate(validator, fn, options):
-    """Performs STIX XML Schema validation against the input filename.
+    """Performs CybOX XML Schema validation against the input filename.
 
     Args:
-        validator: An instance of validators.STIXSchemaValidator
-        fn: A filename for a STIX document
+        validator: An instance of validators.CybOXSchemaValidator
+        fn: A filename for a CybOX document
         options: ValidationOptions instance with validation options for this
             validation run.
 
@@ -415,7 +274,7 @@ def _schema_validate(validator, fn, options):
 
     results = validator.validate(
         fn,
-        version=options.stix_version,
+        version=options.cybox_version,
         schemaloc=options.use_schemaloc
     )
 
@@ -425,106 +284,15 @@ def _schema_validate(validator, fn, options):
     return results
 
 
-def _best_practice_validate(validator, fn, options):
-    """Performs STIX Best Practice validation against the input filename.
-
-    Args:
-        validator: An instance of STIXBestPracticeValidator
-        fn: A filename for a STIX document
-        options: ValidationOptions instance with validation options for
-            this validation run.
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing best practice validation on %s" % fn)
-    results = validator.validate(fn, version=options.stix_version)
-    return results
-
-
-def _profile_validate(validator, fn):
-    """Performs STIX Profile validation against the input filename.
-
-    Args:
-        fn: A filename for a STIX document
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing profile validation on %s" % fn)
-    results = validator.validate(fn)
-    return results
-
-
-def _get_schema_validator(options):
-    """Initializes a ``STIXSchemaValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXSchemaValidator``
-
-    """
-    if not options.schema_validate:
-        return None
-
-    _info("Initializing STIX XML Schema validator")
-    return validators.STIXSchemaValidator(schema_dir=options.schema_dir)
-
-
-def _get_profile_validator(options):
-    """Initializes a ``STIXProfileValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXProfileValidator``
-
-    """
-    if not any((options.profile_validate, options.profile_convert)):
-        return None
-
-    _info("Initializing STIX Profile validator")
-    return validators.STIXProfileValidator(options.in_profile)
-
-
-def _get_best_practice_validator(options):
-    """Initializes a ``STIXBestPracticeValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXBestPracticeValidator``
-
-    """
-    if not options.best_practice_validate:
-        return None
-
-    _info("Initializing STIX Best Practice validator")
-    return validators.STIXBestPracticeValidator()
-
-
-def _validate_file(fn, options, schema_validator=None, profile_validator=None,
-                   best_practice_validator=None):
+def _validate_file(fn, options, schema_validator):
     """Validates the input document `fn` with the validators that are passed
     in.
-
-    Profile and/or Best Practice validation will only occur if `fn` is
-    schema-valid.
 
     If any exceptions are raised during validation, no further validation
     will take place.
 
     Args:
-        schema_validator: An instance of STIXSchemaValidator (optional)
-        profile_validator: An instance of STIXProfileValidator (optional)
-        best_practice_validator: An instance of STIXBestPracticeValidator
-            (optional).
+        schema_validator: An instance of CybOXSchemaValidator (optional)
         options: An instance of ValidationOptions.
 
     Returns:
@@ -534,33 +302,12 @@ def _validate_file(fn, options, schema_validator=None, profile_validator=None,
     results = ValidationResults(fn)
 
     try:
-        if schema_validator:
-            results.schema_results = _schema_validate(
-                schema_validator, fn, options
-            )
-
-        if best_practice_validator:
-            results.best_practice_results = _best_practice_validate(
-                best_practice_validator, fn, options
-            )
-
-        if profile_validator:
-            results.profile_results = _profile_validate(profile_validator, fn)
-
+        results.schema_results = _schema_validate(schema_validator, fn, options)
     except SchemaInvalidError as ex:
         results.schema_results = ex.results
-        if any((profile_validator, best_practice_validator)):
-            msg = (
-                "File %s was schema-invalid. No further validation will be "
-                "performed." % fn
-            )
-            _info(msg)
     except Exception as ex:
         results.fatal = validators.ValidationErrorResults(ex)
-        _info(
-            "Unexpected error occurred with file %s. No further validation "
-            "will be performed: %s" % (fn, str(ex))
-        )
+        _info("Unexpected error occurred with file %s: %s" % (fn, str(ex)))
 
     return results
 
@@ -574,22 +321,12 @@ def _validate(options):
 
     """
     files = utils.get_xml_files(options.in_files, options.recursive)
-    schema_validator = _get_schema_validator(options)
-    profile_validator = _get_profile_validator(options)
-    best_practice_validator = _get_best_practice_validator(options)
+    schema_validator = validators.CyboxSchemaValidator(schema_dir=options.schema_dir)
 
     results = {}
     for fn in files:
-        results[fn] = _validate_file(
-            fn,
-            options,
-            schema_validator=schema_validator,
-            profile_validator=profile_validator,
-            best_practice_validator=best_practice_validator
-        )
-
-    if options.profile_convert:
-        _convert_profile(profile_validator, options)
+        result = _validate_file(fn, options, schema_validator=schema_validator)
+        results[fn] = result
 
     return results
 
@@ -610,25 +347,13 @@ def _set_validation_options(args):
     if (args.files):
         options.schema_validate = True
 
-    if options.schema_validate and args.profile:
-        options.profile_validate = True
-
-    if args.profile and any((args.schematron, args.xslt)):
-        options.profile_convert = True
-
-    # best practice options
-    options.best_practice_validate = args.best_practices
-
     # input options
-    options.stix_version = args.stix_version
+    options.cybox_version = args.cybox_version
     options.schema_dir = args.schema_dir
     options.in_files = args.files
-    options.in_profile = args.profile
     options.recursive = args.recursive
 
     # output options
-    options.xslt_out = args.xslt
-    options.schematron_out = args.schematron
     options.json_results = args.json
     options.quiet_output = args.quiet
 
@@ -648,37 +373,12 @@ def _validate_args(args):
             passed into the application.
 
     """
-    schema_validate = False
-    profile_validate = False
-    profile_convert = False
-
     if len(sys.argv) == 1:
         raise ArgumentError("Invalid arguments", show_help=True)
 
-    if (args.files):
-        schema_validate = True
-
-    if schema_validate and args.profile:
-        profile_validate = True
-
-    if args.profile and any((args.schematron, args.xslt)):
-        profile_convert = True
-
-    if all((args.stix_version, args.use_schemaloc)):
+    if args.cybox_version and args.use_schemaloc:
         raise ArgumentError(
-            "Cannot set both --stix-version and --use-schemalocs"
-        )
-
-    if any((args.xslt, args.schematron)) and not args.profile:
-        raise ArgumentError(
-            "Profile filename is required when profile conversion options "
-            "are set."
-        )
-
-    if (args.profile and not any((profile_validate, profile_convert))):
-        raise ArgumentError(
-            "Profile specified but no conversion options or validation "
-            "options specified."
+            "Cannot set both --cybox-version and --use-schemalocs"
         )
 
 
@@ -691,21 +391,21 @@ def _get_arg_parser():
 
     """
     parser = argparse.ArgumentParser(
-        description="STIX Document Validator v%s" % sdv.__version__
+        description="CybOX Document Validator v%s" % sdv.__version__
     )
 
     parser.add_argument(
-        "--stix-version",
-        dest="stix_version",
+        "--cybox-version",
+        dest="cybox_version",
         default=None,
-        help="The version of STIX to validate against"
+        help="The version of CybOX to validate against"
     )
 
     parser.add_argument(
         "--schema-dir",
         dest="schema_dir",
         default=None,
-        help="Schema directory. If not provided, the STIX schemas bundled "
+        help="Schema directory. If not provided, the CybOX schemas bundled "
              "with the stix-validator library will be used."
     )
 
@@ -715,35 +415,6 @@ def _get_arg_parser():
         action='store_true',
         default=False,
         help="Use schemaLocation attribute to determine schema locations."
-    )
-
-    parser.add_argument(
-        "--best-practices",
-        dest="best_practices",
-        action='store_true',
-        default=False,
-        help="Check that the document follows authoring best practices."
-    )
-
-    parser.add_argument(
-        "--profile",
-        dest="profile",
-        default=None,
-        help="Path to STIX Profile .xlsx file."
-    )
-
-    parser.add_argument(
-        "--schematron-out",
-        dest="schematron",
-        default=None,
-        help="Path to converted STIX profile schematron file output."
-    )
-
-    parser.add_argument(
-        "--xslt-out",
-        dest="xslt",
-        default=None,
-        help="Path to converted STIX profile schematron xslt output."
     )
 
     parser.add_argument(
@@ -774,8 +445,8 @@ def _get_arg_parser():
         "files",
         metavar="FILES",
         nargs="*",
-        help="A whitespace separated list of STIX files or directories of "
-             "STIX files to validate."
+        help="A whitespace separated list of CybOX files or directories of "
+             "CybOX files to validate."
     )
 
     return parser
@@ -793,16 +464,10 @@ def _status_code(results):
 
     for result in results.itervalues():
         schema = result.schema_results
-        best_practice = result.best_practice_results
-        profile = result.profile_results
         fatal = result.fatal
 
         if schema and not schema.is_valid:
             status |= codes.EXIT_SCHEMA_INVALID
-        if best_practice and not best_practice.is_valid:
-            status |= codes.EXIT_BEST_PRACTICE_INVALID
-        if profile and not profile.is_valid:
-            status |= codes.EXIT_PROFILE_INVALID
         if fatal:
             status |= codes.EXIT_VALIDATION_ERROR
 
@@ -815,9 +480,8 @@ def main():
     Parses and validates command line arguments and then does at least one of
     the following:
 
-    * Validates instance document against schema/best practices/profile and
+    * Validates instance document against schemas and
       prints results to stdout.
-    * Converts a STIX profile into xslt and/or schematron formats
     * Prints an error to stderr and exit(1)
 
     """

--- a/sdv/scripts/stix_validator.py
+++ b/sdv/scripts/stix_validator.py
@@ -33,565 +33,13 @@ Attributes:
 """
 import sys
 import logging
-import collections
 import argparse
-import json
 
 import sdv
 import sdv.codes as codes
-import sdv.utils as utils
 import sdv.errors as errors
+import sdv.scripts as scripts
 import sdv.validators as validators
-
-# Only print results and/or system errors.
-quiet = False
-
-class ValidationOptions(object):
-    """Collection of validation options which can be set via command line.
-
-    Attributes:
-        schema_validate: True if XML Schema validation should be performed.
-        schema_dir: A user-defined schema directory to validate against.
-        use_schemaloc: True if the XML Schema validation process should look
-            at the xsi:schemaLocation attribute to find schemas to validate
-            against.
-        stix_version: The version of STIX which should be validated against.
-        profile_validate: True if profile validation should be performed.
-        best_practice_validate: True if STIX best practice validation should
-            be performed.
-        profile_convert: True if a STIX Profile should be converted into
-            schematron or xslt.
-        xslt_out: The filename for the output profile xslt.
-        schematron_out: The filename for the output profile schematron.
-        json_results: True if results should be printed in JSON format.
-        quiet_output: True if only results and fatal errors should be printed
-            to stdout/stderr.
-        in_files: A list of input files and directories of files to be
-            validated.
-        in_profile: A filename/path for a STIX Profile to validate against or
-            convert.
-        recursive: Recursively descend into input directories.
-
-    """
-    def __init__(self):
-        # validation options
-        self.schema_validate = False
-        self.schema_dir = None
-        self.use_schemaloc = False
-        self.stix_version = None
-        self.profile_validate = False
-        self.best_practice_validate = False
-
-        # conversion options
-        self.profile_convert = False
-        self.xslt_out = None
-        self.schematron_out = None
-
-        # output options
-        self.json_results = False
-        self.quiet_output = False
-
-        # input options
-        self.in_files = None
-        self.in_profile = None
-        self.recursive = False
-
-
-class ValidationResults(object):
-    """Stores validation results for given file.
-
-    Args:
-        fn: The filename/path for the file that was validated.
-
-    Attributes:
-        fn: The filename/path for the file that was validated.
-        schema_results: XML schema validation results.
-        best_practice_results: STIX Best Practice validation results.
-        profile_resutls: STIX Profile validation results.
-        fatal: Fatal error
-
-    """
-    def __init__(self, fn=None):
-        self.fn = fn
-        self.schema_results = None
-        self.best_practice_results = None
-        self.profile_results = None
-        self.fatal = None
-
-
-class ArgumentError(Exception):
-    """An exception to be raised when invalid or incompatible arguments are
-    passed into the application via the command line.
-
-    Args:
-        show_help (bool): If true, the help/usage information should be printed
-            to the screen.
-
-    Attributes:
-        show_help (bool): If true, the help/usage information should be printed
-            to the screen.
-
-    """
-    def __init__(self, msg=None, show_help=False):
-        super(ArgumentError, self).__init__(msg)
-        self.show_help = show_help
-
-
-class SchemaInvalidError(Exception):
-    """Exception to be raised when schema validation fails for a given
-    STIX document.
-
-    Attributes:
-        results: An instance of sdv.validators.XmlValidationResults.
-
-    """
-    def __init__(self, msg=None, results=None):
-        super(SchemaInvalidError, self).__init__(msg)
-        self.results = results
-
-
-def _error(msg, status=codes.EXIT_FAILURE):
-    """Prints a message to the stderr prepended by '[!]' and calls
-    ```sys.exit(status)``.
-
-    Args:
-        msg: The error message to print.
-        status: The exit status code. Defaults to ``EXIT_FAILURE`` (1).
-
-    """
-    sys.stderr.write("[!] %s\n" % str(msg))
-    sys.exit(status)
-
-
-def _info(msg):
-    """Prints a message to stdout, prepended by '[-]'.
-
-    Note:
-        If the application is running in "Quiet Mode"
-        (i.e., ``quiet == True``), this function will return
-        immediately and no message will be printed.
-
-    Args:
-        msg: The message to print.
-
-    """
-    if quiet:
-        return
-
-    print "[-] %s" % msg
-
-
-def _print_level(fmt, level, *args):
-    """Prints a formatted message to stdout prepended by spaces. Useful for
-    printing hierarchical information, like bullet lists.
-
-    Args:
-        fmt (str): A Python formatted string.
-        level (int): Used to determing how many spaces to print. The formula
-            is ``'    ' * level ``.
-        *args: Variable length list of arguments. Values are plugged into the
-            format string.
-
-    Examples:
-        >>> _print_level("%s %d", 0, "TEST", 0)
-        TEST 0
-        >>> _print_level("%s %d", 1, "TEST", 1)
-            TEST 1
-        >>> _print_level("%s %d", 2, "TEST", 2)
-                TEST 2
-
-    """
-    msg = fmt % args
-    spaces = '    ' * level
-    print "%s%s" % (spaces, msg)
-
-
-def _set_output_level(options):
-    """Set the output level for the application.
-
-    If the ``quiet_output`` or ``json_results`` attributes are set on `options`
-    then the application does not print informational messages to stdout; only
-    results or fatal errors are printed to stdout.
-
-    """
-    global quiet
-    quiet = options.quiet_output or options.json_results
-
-
-def _print_fatal_results(results, level=0):
-    """Prints fatal errors that occurred during validation runs."""
-    _print_level("[!] Fatal Error: %s", level, results.error)
-
-
-def _print_schema_results(results, level=0):
-    """Prints STIX Schema validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.XmlSchemaResults.
-        level: The level to print the results.
-
-    """
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] XML Schema: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    for error in results.errors:
-        _print_level("[!] %s", level+1, error)
-
-
-def _print_best_practice_results(results, level=0):
-    """Prints STIX Best Practice validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.STIXBestPracticeResults
-        level: The level to print the results.
-
-    """
-    def _print_warning(warning, level):
-        core_keys = warning.core_keys
-
-        # Print "core" values (e.g., id, idref, tag, etc.)
-        for key in (x for x in warning if x in core_keys):
-            _print_level("[-] %s : %s", level, key, warning[key])
-
-        # Print "other" values (e.g., 'found version')
-        for key in (x for x in warning if x not in core_keys):
-            _print_level("[-] %s : %s", level, key, warning[key])
-
-    def _print_warnings(collection, level):
-        for warning in collection:
-            _print_warning(warning, level)
-
-            # Print a divider if not the last warning
-            if warning is not collection[-1]:
-                _print_level("-"*80, level)
-
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] Best Practices: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    for collection in sorted(results, key=lambda x: x.name):
-        _print_level("[!] %s", level+1, collection.name)
-        _print_warnings(collection, level+2)
-
-
-def _print_profile_results(results, level):
-    """Prints STIX Profile validation results to stdout.
-
-    Args:
-        results: An instance of sdv.validators.STIXProfileResults.
-        level: The level to print the results.
-
-    """
-    marker = "+" if results.is_valid else "!"
-    _print_level("[%s] Profile: %s", level, marker, results.is_valid)
-
-    if results.is_valid:
-        return
-
-    errors_ = collections.defaultdict(list)
-    for e in results.errors:
-        errors_[e.message].append(e.line)
-
-    for msg, lines in errors_.iteritems():
-        _print_level("[!] %s [%s]", level+1, msg, ', '.join(lines))
-
-
-def _print_json_results(results):
-    """Prints `results` to stdout in JSON format.
-
-    Args:
-        results: An instance of ``ValidationResults`` which contains the
-            results to print.
-    """
-    json_results = {}
-    for fn, result in results.iteritems():
-        d = {}
-        if result.schema_results is not None:
-            d['schema validation'] = result.schema_results.as_dict()
-        if result.profile_results is not None:
-            d['profile results'] = result.profile_results.as_dict()
-        if result.best_practice_results is not None:
-            d['best practice results'] = result.best_practice_results.as_dict()
-        if result.fatal is not None:
-            d['fatal'] = result.fatal.as_dict()
-
-        json_results[fn] = d
-
-    print json.dumps(json_results)
-
-
-def _print_results(results, options):
-    """Prints `results` to stdout. If ``options.json_output`` is set, the
-    results are printed in JSON format.
-
-    Args:
-        results: A dictionary of ValidationResults instances. The key is the
-            file path to the validated document.
-        options: An instance of ``ValidationOptions`` which contains output
-            options.
-
-    """
-    if options.json_results:
-        _print_json_results(results)
-        return
-
-    level = 0
-    for fn, result in sorted(results.iteritems()):
-        print "=" * 80
-        _print_level("[-] Results: %s", level, fn)
-
-        if result.schema_results is not None:
-            _print_schema_results(result.schema_results, level)
-        if result.best_practice_results is not None:
-            _print_best_practice_results(result.best_practice_results, level)
-        if result.profile_results is not None:
-            _print_profile_results(result.profile_results, level)
-        if result.fatal is not None:
-            _print_fatal_results(result.fatal, level)
-
-
-def _convert_profile(validator, options):
-    """Converts a STIX Profile to XSLT and/or Schematron formats.
-
-    This converts a STIX Profile document and writes the results to output
-    schematron and/or xslt files to the output file names.
-
-    The output file names are defined by
-    ``output.xslt_out`` and ``options.schematron_out``.
-
-    Args:
-        validator: An instance of STIXProfileValidator
-        options: ValidationOptions instance with validation options for this
-            validation run.
-
-    """
-    xslt = validator.xslt
-    xslt_out_fn = options.xslt_out
-    schematron = validator.schematron
-    schematron_out_fn = options.schematron_out
-
-    if schematron_out_fn:
-        _info(
-            "Writing schematron conversion of profile to %s" %
-            schematron_out_fn
-        )
-
-        schematron.write(
-            schematron_out_fn,
-            pretty_print=True,
-            xml_declaration=True,
-            encoding="UTF-8"
-        )
-
-    if xslt_out_fn:
-        _info("Writing xslt conversion of profile to %s" % xslt_out_fn)
-        xslt.write(
-            xslt_out_fn,
-            pretty_print=True,
-            xml_declaration=True,
-            encoding="UTF-8"
-        )
-
-
-def _schema_validate(validator, fn, options):
-    """Performs STIX XML Schema validation against the input filename.
-
-    Args:
-        validator: An instance of validators.STIXSchemaValidator
-        fn: A filename for a STIX document
-        options: ValidationOptions instance with validation options for this
-            validation run.
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing xml schema validation on %s" % fn)
-
-    results = validator.validate(
-        fn,
-        version=options.stix_version,
-        schemaloc=options.use_schemaloc
-    )
-
-    if not results.is_valid:
-        raise SchemaInvalidError(results=results)
-
-    return results
-
-
-def _best_practice_validate(validator, fn, options):
-    """Performs STIX Best Practice validation against the input filename.
-
-    Args:
-        validator: An instance of STIXBestPracticeValidator
-        fn: A filename for a STIX document
-        options: ValidationOptions instance with validation options for
-            this validation run.
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing best practice validation on %s" % fn)
-    results = validator.validate(fn, version=options.stix_version)
-    return results
-
-
-def _profile_validate(validator, fn):
-    """Performs STIX Profile validation against the input filename.
-
-    Args:
-        fn: A filename for a STIX document
-
-    Returns:
-        A dictionary of validation results
-
-    """
-    _info("Performing profile validation on %s" % fn)
-    results = validator.validate(fn)
-    return results
-
-
-def _get_schema_validator(options):
-    """Initializes a ``STIXSchemaValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXSchemaValidator``
-
-    """
-    if not options.schema_validate:
-        return None
-
-    _info("Initializing STIX XML Schema validator")
-    return validators.STIXSchemaValidator(schema_dir=options.schema_dir)
-
-
-def _get_profile_validator(options):
-    """Initializes a ``STIXProfileValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXProfileValidator``
-
-    """
-    if not any((options.profile_validate, options.profile_convert)):
-        return None
-
-    _info("Initializing STIX Profile validator")
-    return validators.STIXProfileValidator(options.in_profile)
-
-
-def _get_best_practice_validator(options):
-    """Initializes a ``STIXBestPracticeValidator`` instance.
-
-    Args:
-        options: An instance of ``ValidationOptions``
-
-    Returns:
-        An instance of ``STIXBestPracticeValidator``
-
-    """
-    if not options.best_practice_validate:
-        return None
-
-    _info("Initializing STIX Best Practice validator")
-    return validators.STIXBestPracticeValidator()
-
-
-def _validate_file(fn, options, schema_validator=None, profile_validator=None,
-                   best_practice_validator=None):
-    """Validates the input document `fn` with the validators that are passed
-    in.
-
-    Profile and/or Best Practice validation will only occur if `fn` is
-    schema-valid.
-
-    If any exceptions are raised during validation, no further validation
-    will take place.
-
-    Args:
-        schema_validator: An instance of STIXSchemaValidator (optional)
-        profile_validator: An instance of STIXProfileValidator (optional)
-        best_practice_validator: An instance of STIXBestPracticeValidator
-            (optional).
-        options: An instance of ValidationOptions.
-
-    Returns:
-        An instance of ValidationResults.
-
-    """
-    results = ValidationResults(fn)
-
-    try:
-        if schema_validator:
-            results.schema_results = _schema_validate(
-                schema_validator, fn, options
-            )
-
-        if best_practice_validator:
-            results.best_practice_results = _best_practice_validate(
-                best_practice_validator, fn, options
-            )
-
-        if profile_validator:
-            results.profile_results = _profile_validate(profile_validator, fn)
-
-    except SchemaInvalidError as ex:
-        results.schema_results = ex.results
-        if any((profile_validator, best_practice_validator)):
-            msg = (
-                "File %s was schema-invalid. No further validation will be "
-                "performed." % fn
-            )
-            _info(msg)
-    except Exception as ex:
-        results.fatal = validators.ValidationErrorResults(ex)
-        _info(
-            "Unexpected error occurred with file %s. No further validation "
-            "will be performed: %s" % (fn, str(ex))
-        )
-
-    return results
-
-
-def _validate(options):
-    """Validates files based on command line options.
-
-    Args:
-        options: An instance of ``ValidationOptions`` containing options for
-            this validation run.
-
-    """
-    files = utils.get_xml_files(options.in_files, options.recursive)
-    schema_validator = _get_schema_validator(options)
-    profile_validator = _get_profile_validator(options)
-    best_practice_validator = _get_best_practice_validator(options)
-
-    results = {}
-    for fn in files:
-        results[fn] = _validate_file(
-            fn,
-            options,
-            schema_validator=schema_validator,
-            profile_validator=profile_validator,
-            best_practice_validator=best_practice_validator
-        )
-
-    if options.profile_convert:
-        _convert_profile(profile_validator, options)
-
-    return results
 
 
 def _set_validation_options(args):
@@ -605,7 +53,7 @@ def _set_validation_options(args):
         Instance of ``ValidationOptions``.
 
     """
-    options = ValidationOptions()
+    options = scripts.ValidationOptions()
 
     if (args.files):
         options.schema_validate = True
@@ -620,7 +68,7 @@ def _set_validation_options(args):
     options.best_practice_validate = args.best_practices
 
     # input options
-    options.stix_version = args.stix_version
+    options.lang_version = args.lang_version
     options.schema_dir = args.schema_dir
     options.in_files = args.files
     options.in_profile = args.profile
@@ -631,6 +79,9 @@ def _set_validation_options(args):
     options.schematron_out = args.schematron
     options.json_results = args.json
     options.quiet_output = args.quiet
+
+    # validation class options
+    options.xml_validation_class = validators.STIXSchemaValidator
 
     return options
 
@@ -653,7 +104,7 @@ def _validate_args(args):
     profile_convert = False
 
     if len(sys.argv) == 1:
-        raise ArgumentError("Invalid arguments", show_help=True)
+        raise scripts.ArgumentError("Invalid arguments", show_help=True)
 
     if (args.files):
         schema_validate = True
@@ -664,19 +115,19 @@ def _validate_args(args):
     if args.profile and any((args.schematron, args.xslt)):
         profile_convert = True
 
-    if all((args.stix_version, args.use_schemaloc)):
-        raise ArgumentError(
+    if all((args.lang_version, args.use_schemaloc)):
+        raise scripts.ArgumentError(
             "Cannot set both --stix-version and --use-schemalocs"
         )
 
     if any((args.xslt, args.schematron)) and not args.profile:
-        raise ArgumentError(
+        raise scripts.ArgumentError(
             "Profile filename is required when profile conversion options "
             "are set."
         )
 
     if (args.profile and not any((profile_validate, profile_convert))):
-        raise ArgumentError(
+        raise scripts.ArgumentError(
             "Profile specified but no conversion options or validation "
             "options specified."
         )
@@ -696,7 +147,7 @@ def _get_arg_parser():
 
     parser.add_argument(
         "--stix-version",
-        dest="stix_version",
+        dest="lang_version",
         default=None,
         help="The version of STIX to validate against"
     )
@@ -781,34 +232,6 @@ def _get_arg_parser():
     return parser
 
 
-def _status_code(results):
-    """Determines the exit status code to be returned from this script
-    by inspecting the results returned from validating file(s).
-
-    Status codes are binary OR'd together, so exit codes can communicate
-    multiple error conditions.
-
-    """
-    status = codes.EXIT_SUCCESS
-
-    for result in results.itervalues():
-        schema = result.schema_results
-        best_practice = result.best_practice_results
-        profile = result.profile_results
-        fatal = result.fatal
-
-        if schema and not schema.is_valid:
-            status |= codes.EXIT_SCHEMA_INVALID
-        if best_practice and not best_practice.is_valid:
-            status |= codes.EXIT_BEST_PRACTICE_INVALID
-        if profile and not profile.is_valid:
-            status |= codes.EXIT_PROFILE_INVALID
-        if fatal:
-            status |= codes.EXIT_VALIDATION_ERROR
-
-    sys.exit(status)
-
-
 def main():
     """Entry point for sdv.py.
 
@@ -832,24 +255,24 @@ def main():
         options = _set_validation_options(args)
 
         # Set the output level (e.g., quiet vs. verbose)
-        _set_output_level(options)
+        scripts.set_output_level(options)
 
         # Validate input documents
-        results = _validate(options)
+        results = scripts.run_validation(options)
 
         # Print validation results
-        _print_results(results, options)
+        scripts.print_results(results, options)
 
         # Determine exit status code and exit.
-        code = _status_code(results)
+        code = scripts.status_code(results)
         sys.exit(code)
 
-    except ArgumentError as ex:
+    except scripts.ArgumentError as ex:
         if ex.show_help:
             parser.print_help()
-        _error(ex)
+        scripts.error(ex)
     except (errors.ValidationError, IOError) as ex:
-        _error(
+        scripts.error(
             "Validation error occurred: '%s'" % str(ex),
             codes.EXIT_VALIDATION_ERROR
         )

--- a/sdv/scripts/stix_validator.py
+++ b/sdv/scripts/stix_validator.py
@@ -39,8 +39,8 @@ import json
 
 import sdv
 import sdv.codes as codes
-import sdv.errors as errors
 import sdv.utils as utils
+import sdv.errors as errors
 import sdv.validators as validators
 
 # Only print results and/or system errors.

--- a/sdv/test/cybox_schema_tests.py
+++ b/sdv/test/cybox_schema_tests.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+import unittest
+from StringIO import StringIO
+
+import sdv
+import sdv.errors as errors
+
+CYBOX_2_1_XML = \
+"""
+<cybox:Observables xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+    xmlns:URIObject="http://cybox.mitre.org/objects#URIObject-2"
+    xmlns:example="http://example.com/"
+    cybox_major_version="2"
+    cybox_minor_version="1"
+    cybox_update_version="0">
+    <cybox:Observable id="example:Observable-0b9af310-0d5a-4c44-bdd7-aea3d99f13b6">
+        <cybox:Object id="example:Object-15be6630-b2df-4bf9-8750-3f45ca9e19cf">
+            <cybox:Properties xsi:type="URIObject:URIObjectType" type="Domain Name">
+                <URIObject:Value>example.com</URIObject:Value>
+            </cybox:Properties>
+        </cybox:Object>
+    </cybox:Observable>
+</cybox:Observables>
+"""
+
+CYBOX_2_1_NO_UPDATE_VER_XML = \
+"""
+<cybox:Observables xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+    xmlns:URIObject="http://cybox.mitre.org/objects#URIObject-2"
+    xmlns:example="http://example.com/"
+    cybox_major_version="2"
+    cybox_minor_version="1">
+    <cybox:Observable id="example:Observable-0b9af310-0d5a-4c44-bdd7-aea3d99f13b6">
+        <cybox:Object id="example:Object-15be6630-b2df-4bf9-8750-3f45ca9e19cf">
+            <cybox:Properties xsi:type="URIObject:URIObjectType" type="Domain Name">
+                <URIObject:Value>example.com</URIObject:Value>
+            </cybox:Properties>
+        </cybox:Object>
+    </cybox:Observable>
+</cybox:Observables>
+"""
+
+CYBOX_INVALID = \
+"""
+<cybox:Observables xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    cybox_major_version="2"
+    cybox_minor_version="1"
+    cybox_update_version="0">
+    <cybox:BAD_ELEMENT>This should raise an error</cybox:BAD_ELEMENT>
+</cybox:Observables>
+"""
+
+
+class CyboxSchemaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        StringIO(CYBOX_2_1_XML)
+
+    def test_invalid(self):
+        xml = StringIO(CYBOX_INVALID)
+        results = sdv.validate_xml(xml)
+
+        # Assert that the document is identified as being invalid
+        self.assertFalse(results.is_valid)
+
+        # Assert that the badAttr attribute is the only error recorded
+        self.assertEqual(len(results.errors), 1)
+
+    def test_valid(self):
+        xml = StringIO(CYBOX_2_1_XML)
+        results = sdv.validate_xml(xml)
+        self.assertTrue(results.is_valid)
+
+    def test_invalid_version(self):
+        xml = StringIO(CYBOX_2_1_XML)
+        func = sdv.validate_xml
+        self.assertRaises(
+            errors.InvalidCyboxVersionError, func, xml, version="INVALID"
+        )
+
+    def test_defined_version(self):
+        xml = StringIO(CYBOX_2_1_XML)
+        results = sdv.validate_xml(xml, version="2.1")
+        self.assertTrue(results.is_valid)
+
+    def test_invalid_doc(self):
+        func = sdv.validate_xml
+        self.assertRaises(errors.ValidationError, func, "INVALID XML DOC")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -32,7 +32,8 @@ def get_xml_parser(encoding=None):
         resolve_entities=False,
         remove_comments=False,
         strip_cdata=False,
-        remove_blank_text=True
+        remove_blank_text=True,
+        encoding=encoding
     )
 
     return parser

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -183,21 +183,50 @@ def get_type_ns(doc, typename):
 
 
 def get_namespace(node):
+    """Returns the namespace for which `node` falls under.
+
+    Args:
+        node: An etree node.
+
+    """
     qname = etree.QName(node)
     return qname.namespace
 
 
 def is_stix(doc):
+    """Attempts to determine if the input `doc` is a STIX XML instance document.
+    If the root-level element falls under a namespace which starts with
+    ``http://stix.mitre.org``, this will return True.
+
+    """
     root = get_etree_root(doc)
     namespace = get_namespace(root)
     return namespace.startswith("http://stix.mitre.org")
 
 
 def is_cybox(doc):
+    """Attempts to determine if the input `doc` is a CybOX XML instance
+    document. If the root-level element falls under a namespace which starts
+    with ``http://cybox.mitre.org``, this will return True.
+
+    """
+
     root = get_etree_root(doc)
     namespace = get_namespace(root)
     return namespace.startswith("http://cybox.mitre.org")
 
 
 def is_version_equal(x, y):
+    """Attempts to determine if the `x` amd `y` version numbers are semantically
+    equivalent.
+
+    Examples:
+        The version strings "2.1.0" and "2.1" represent semantically equivalent
+        versions, despite not being equal strings.
+
+    Args:
+        x: A string version number. Ex: '2.1.0'
+        y: A string version number. Ex: '2.1'
+
+    """
     return StrictVersion(x) == StrictVersion(y)

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -25,7 +25,7 @@ def ignored(*exceptions):
         pass
 
 
-def get_xml_parser():
+def get_xml_parser(encoding=None):
     """Returns an ``etree.ETCompatXMLParser`` instance."""
     parser = etree.ETCompatXMLParser(
         huge_tree=True,

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -4,6 +4,7 @@ import contextlib
 
 # external
 from lxml import etree
+from distutils.version import StrictVersion
 
 # internal
 import sdv.errors as errors
@@ -179,3 +180,24 @@ def get_type_ns(doc, typename):
         raise errors.ValidationError(
             "xsi:type '%s' contains unresolvable namespace prefix." % typename
         )
+
+
+def get_namespace(node):
+    qname = etree.QName(node)
+    return qname.namespace
+
+
+def is_stix(doc):
+    root = get_etree_root(doc)
+    namespace = get_namespace(root)
+    return namespace.startswith("http://stix.mitre.org")
+
+
+def is_cybox(doc):
+    root = get_etree_root(doc)
+    namespace = get_namespace(root)
+    return namespace.startswith("http://cybox.mitre.org")
+
+
+def is_version_equal(x, y):
+    return StrictVersion(x) == StrictVersion(y)

--- a/sdv/validators/__init__.py
+++ b/sdv/validators/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
+from sdv import errors, utils
 from .base import ValidationResults
+
 
 class ValidationErrorResults(ValidationResults):
     """Can be used to communicate a failed validation due to a raised Exception.
@@ -30,11 +32,26 @@ class ValidationErrorResults(ValidationResults):
 
         return d
 
+
 from .xml_schema import *
 from .schematron import *
 from .stix import *
+from .cybox import *
 
 
-__all__ = [
-    'ValidationErrorResults'
-]
+def get_xml_validator_class(doc):
+    root = utils.get_etree_root(doc)
+
+    if utils.is_stix(root):
+        return STIXSchemaValidator
+
+    if utils.is_cybox(root):
+        return CyboxSchemaValidator
+
+    ns = utils.get_namespace(root)
+    error = (
+        "Unable determine validator class for input type. Root element "
+        "namespace: {0}"
+    ).format(ns)
+
+    raise errors.ValidationError(error)

--- a/sdv/validators/__init__.py
+++ b/sdv/validators/__init__.py
@@ -40,6 +40,18 @@ from .cybox import *
 
 
 def get_xml_validator_class(doc):
+    """Returns the XML validator class required to validate the input
+    `doc`.
+
+    Args:
+        doc: An XML document. This can be a filename, file-like object,
+            ``etree._Element``, or ``etree._ElementTree`` instance.
+
+    Returns:
+        An XML Schema validator class (not object instance) which provides
+        validation functionality required to validate `doc`.
+
+    """
     root = utils.get_etree_root(doc)
 
     if utils.is_stix(root):

--- a/sdv/validators/cybox/__init__.py
+++ b/sdv/validators/cybox/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2015, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+from .schema import *

--- a/sdv/validators/cybox/common.py
+++ b/sdv/validators/cybox/common.py
@@ -1,6 +1,5 @@
-
-# builtin
-from distutils.version import StrictVersion
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
 
 # internal
 import sdv.errors as errors

--- a/sdv/validators/cybox/common.py
+++ b/sdv/validators/cybox/common.py
@@ -1,0 +1,72 @@
+
+# builtin
+from distutils.version import StrictVersion
+
+# internal
+import sdv.errors as errors
+import sdv.utils as utils
+
+
+NS_XSI = "http://www.w3.org/2001/XMLSchema-instance"
+
+TAG_XSI_TYPE = "{%s}type" % NS_XSI
+TAG_CYBOX_MAJOR  = "cybox_major_version"
+TAG_CYBOX_MINOR  = "cybox_minor_version"
+TAG_CYBOX_UPDATE = "cybox_update_version"
+
+CYBOX_VERSIONS = ('2.0', '2.0.1', '2.1')
+
+
+def get_version(doc):
+    """Returns the version of the `observables` ``Observables`` node.
+
+    Returns:
+        A dotted-decimal a version string from the ``cybox_major``,
+        ``cybox_minor`` and ``cybox_update`` attribute values.
+
+    Raises:
+        UnknownVersionError: If `observables` does not contain any of the
+            following attributes:
+
+            * ``cybox_major_version``
+            * ``cybox_minor_version``
+            * ``cybox_update_version``
+
+    """
+    observables  = utils.get_etree_root(doc)
+    cybox_major  = observables.attrib.get(TAG_CYBOX_MAJOR)
+    cybox_minor  = observables.attrib.get(TAG_CYBOX_MINOR)
+    cybox_update = observables.attrib.get(TAG_CYBOX_UPDATE)
+
+    if not any((cybox_major, cybox_minor, cybox_update)):
+        raise errors.UnknownCyboxVersionError(
+            "The input CybOX document has no version information."
+        )
+
+    if cybox_update not in (None, '0'):
+        version = "%s.%s.%s" % (cybox_major, cybox_minor, cybox_update)
+    else:
+        version = "%s.%s" % (cybox_major, cybox_minor)
+
+    return version
+
+
+def check_version(version):
+    """Raises an exception if `version` is not a valid CybOX version.
+
+    Args:
+        version: A string CybOX version. Example: '2.1'
+
+    Raises:
+        .InvalidCyboxVersionError: If `version` is not a valid version of
+            CybOX.
+
+    """
+    if version in CYBOX_VERSIONS:
+        return
+
+    raise errors.InvalidCyboxVersionError(
+        message="Invalid CybOX version: '%s'" % version,
+        expected=CYBOX_VERSIONS,
+        found=version
+    )

--- a/sdv/validators/cybox/schema.py
+++ b/sdv/validators/cybox/schema.py
@@ -9,34 +9,14 @@ import sdv
 import sdv.utils as utils
 import sdv.errors as errors
 from sdv.validators import xml_schema as xml
-from sdv.validators.stix import common as stix
+from sdv.validators.cybox import common as cybox
 
 
-class _XmlSchemaValidator(xml.XmlSchemaValidator):
-    """Needed to resolve namespace collisions between CybOX 2.1 and
-    STIX v1.1.1.
-
-    CybOX imports CPE 2.3. The STIX CVRF extension imports CPE 2.2a. Both
-    are defined within the 'http://cpe.mitre.org/language/2.0' namespace,
-    which results in a namespace collision.
-
-    To resolve this, we force the 'http://cpe.mitre.org/language/2.0' namespace
-    to map to the CPE 2.3 schemas.
-
-    """
-    OVERRIDE_SCHEMALOC = {
-        'http://cpe.mitre.org/language/2.0': os.path.join(
-            sdv.XSD_ROOT, 'stix_1.1.1', 'cybox', 'external', 'cpe_2.3', 'cpe-language_2.3.xsd'
-        )
-    }
-
-
-class STIXSchemaValidator(object):
+class CyboxSchemaValidator(object):
     SCHEMAS = {
-        '1.1.1': os.path.join(sdv.XSD_ROOT, 'stix_1.1.1'),
-        '1.1': os.path.join(sdv.XSD_ROOT, 'stix_1.1'),
-        '1.0.1': os.path.join(sdv.XSD_ROOT, 'stix_1.0.1'),
-        '1.0': os.path.join(sdv.XSD_ROOT, 'stix_1.0')
+        '2.1': os.path.join(sdv.XSD_ROOT, 'stix_1.1.1', 'cybox'),
+        '2.0.1': os.path.join(sdv.XSD_ROOT, 'stix_1.0.1', 'cybox'),
+        '2.0': os.path.join(sdv.XSD_ROOT, 'stix_1.0', 'cybox')
     }
 
     _KEY_SCHEMALOC = 'schemaloc'
@@ -47,36 +27,36 @@ class STIXSchemaValidator(object):
         self._is_user_defined = bool(schema_dir)
 
     def _get_validators(self, schema_dir=None):
-        validators = {self._KEY_SCHEMALOC: _XmlSchemaValidator()}
+        validators = {self._KEY_SCHEMALOC: xml.XmlSchemaValidator()}
 
         if schema_dir:
             validators = {
-                self._KEY_USER_DEFINED: _XmlSchemaValidator(schema_dir)
+                self._KEY_USER_DEFINED: xml.XmlSchemaValidator(schema_dir)
             }
         else:
             for version, location in self.SCHEMAS.iteritems():
-                validator = _XmlSchemaValidator(location)
+                validator = xml.XmlSchemaValidator(location)
                 validators[version] = validator
 
         return validators
 
     def _get_version(self, doc):
         try:
-            return stix.get_version(doc)
+            return cybox.get_version(doc)
         except KeyError:
-            raise errors.UnknownSTIXVersionError(
-                "Unable to validate instance document. STIX version not "
+            raise errors.UnknownCyboxVersionError(
+                "Unable to validate instance document. CybOX version not "
                 "found in instance document and not supplied to validate() "
                 "method"
             )
 
     def validate(self, doc, version=None, schemaloc=False):
-        """Performs XML Schema validation against a STIX document.
+        """Performs XML Schema validation against a CybOX document.
 
         Args:
-            doc: The STIX document. This can be a filename, file-like object,
+            doc: The CybOX document. This can be a filename, file-like object,
                 ``etree._Element``, or ``etree._ElementTree`` instance.
-            version: The version of the STIX document. If ``None`` an attempt
+            version: The version of the CybOX document. If ``None`` an attempt
                 will be made to extract the version from `doc`.
             schemaloc: If ``True``, the ``xsi:schemaLocation`` attribute on
                 `doc` will be used to drive the validation.
@@ -86,10 +66,10 @@ class STIXSchemaValidator(object):
             :class:`.XmlValidationResults`.
 
         Raises:
-            .UnknownSTIXVersionError: If `version` is ``None`` and
-                `doc` does not contain STIX version information.
-            .InvalidSTIXVersionError: If `version` is an invalid
-                STIX version or `doc` contains an invalid STIX version number.
+            .UnknownCyboxVersionError: If `version` is ``None`` and
+                `doc` does not contain CybOX version information.
+            .InvalidCyboxVersionError: If `version` is an invalid
+                CybOX version or `doc` contains an invalid CybOX version number.
             .ValidationError: If the class was not initialized with a
                 schema directory and `schemaloc` is ``False``.
             .XMLSchemaImportError: If an error occurs while processing the
@@ -107,7 +87,7 @@ class STIXSchemaValidator(object):
             validator = self._xml_validators[self._KEY_USER_DEFINED]
         else:
             version = version or self._get_version(doc)
-            stix.check_version(version)
+            cybox.check_version(version)
             validator = self._xml_validators[version]
 
         results = validator.validate(root, schemaloc)
@@ -115,5 +95,5 @@ class STIXSchemaValidator(object):
 
 
 __all__ = [
-    'STIXSchemaValidator'
+    'CyboxSchemaValidator'
 ]

--- a/sdv/validators/cybox/schema.py
+++ b/sdv/validators/cybox/schema.py
@@ -50,6 +50,13 @@ class CyboxSchemaValidator(object):
                 "method"
             )
 
+    def _check_root(self, doc):
+        if utils.is_cybox(doc):
+            return
+
+        error = "Input document does not contain a valid CybOX root element."
+        raise errors.ValidationError(error)
+
     def validate(self, doc, version=None, schemaloc=False):
         """Performs XML Schema validation against a CybOX document.
 
@@ -80,6 +87,9 @@ class CyboxSchemaValidator(object):
 
         """
         root = utils.get_etree_root(doc)
+
+        # Check that this is a CybOX document
+        self._check_root(root)
 
         if schemaloc:
             validator = self._xml_validators[self._KEY_SCHEMALOC]

--- a/sdv/validators/stix/schema.py
+++ b/sdv/validators/stix/schema.py
@@ -70,6 +70,13 @@ class STIXSchemaValidator(object):
                 "method"
             )
 
+    def _check_root(self, doc):
+        if utils.is_stix(doc):
+            return
+
+        error = "Input document does not contain a valid STIX root element."
+        raise errors.ValidationError(error)
+
     def validate(self, doc, version=None, schemaloc=False):
         """Performs XML Schema validation against a STIX document.
 
@@ -100,6 +107,9 @@ class STIXSchemaValidator(object):
 
         """
         root = utils.get_etree_root(doc)
+
+        # check that this is a STIX document
+        self._check_root(root)
 
         if schemaloc:
             validator = self._xml_validators[self._KEY_SCHEMALOC]

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ extras_require = {
 
 setup(
     name='stix-validator',
-    description='STIX Document Validator',
+    description='APIs and scripts for validating STIX and CybOX documents.',
     author='The MITRE Corporation',
     author_email='stix@mitre.org',
     url='http://stix.mitre.org/',
     version=get_version(),
     packages=find_packages(),
-    scripts=['sdv/scripts/stix_validator.py'],
+    scripts=['sdv/scripts/stix_validator.py', 'sdv/scripts/cybox_validator.py'],
     include_package_data=True,
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
This pull request includes the following:
* Added `cybox_validator.py` installable script
* Added a `sdv.validators.cybox` subpackage
* Added a `CyboxSchemaValidator` class for validating CybOX XML documents
* Refactored `utils` subpackage to `utils.py` module
* Added `is_stix()`, `is_cybox()`, `get_namespace()`, and `is_version_equal()` methods to `utils.py`
* Refactored `sdv.validate_xml()` to validate both STIX and CybOX documents
* General code cleanup
