### PR TITLE
Reverted version behavior

### DIFF
--- a/docs/examples/schema.rst
+++ b/docs/examples/schema.rst
@@ -57,6 +57,8 @@ methods (and all other validation methods) can also accept file-like objects
 instances, or ``etree._ElementTree`` instances. Super duper neato!
 
 
+.. _non-bundled schemas:
+
 Using Non-bundled Schemas
 -------------------------
 
@@ -84,6 +86,8 @@ directory containing all the schemas required for validation.
     schemas necessary for validation be found under the directory. This
     includes STIX schemas!
 
+.. _xsi-schemaLocation:
+
 Using ``xsi:schemaLocation``
 ----------------------------
 
@@ -104,8 +108,15 @@ by making use of the ``schemaloc`` parameter,
 STIX and CybOX Versions
 -----------------------
 
-By default, the **stix-validator** will attempt to determine the version of the
-input STIX/CybOX document by inspecting the document for version information.
+The **stix-validator** is bundled with official STIX and CybOX schemas, which
+enables validation of STIX and CybOX XML documents without requiring users
+to provide schemas.
+
+Because we bundle several versions of the STIX and CybOX schemas, the
+**stix-validator** needs to know what version of STIX or CybOX to validate
+input documents against. By default, the **stix-validator** will attempt to
+determine the version of the input STIX/CybOX document by inspecting the
+document for version information.
 
 If the input document contains no version information, users must declare
 a version for the STIX/CybOX document via the ``version`` parameter:
@@ -120,6 +131,18 @@ a version for the STIX/CybOX document via the ``version`` parameter:
 
     # Print the result!
     print results.is_valid
+
+
+.. note::
+
+    No version information is required by the **stix-validator** when performing
+    validation against :ref:`non-bundled schemas <non-bundled schemas>` or when
+    validating using :ref:`xsi:schemaLocation <xsi-schemaLocation>`.
+    Any ``version`` values that are passed in will be **ignored** by the API.
+
+    **However**, the schemas may define constraints or requirements for version
+    numbers, so validation errors regarding invalid or missing version
+    numbers are still reported as :class:`.XmlSchemaError` objects.
 
 Unknown Versions
 ~~~~~~~~~~~~~~~~

--- a/sdv/validators/cybox/common.py
+++ b/sdv/validators/cybox/common.py
@@ -78,10 +78,7 @@ def check_root(doc):
 
 
 def check_cybox(func):
-    """Decorator which checks that the input document is a STIX document
-    and that it contains a valid STIX version number.
-
-    """
+    """Decorator which checks that the input document is a CybOX document."""
     @functools.wraps(func)
     def _check_cybox(*args, **kwargs):
         try:
@@ -89,19 +86,11 @@ def check_cybox(func):
         except IndexError:
             doc = kwargs['doc']
 
-        try:
-            version = args[2]
-        except IndexError:
-            version = kwargs.get('version')
-
-        doc = utils.get_etree_root(doc)
+        # Get the root element for the input doc
+        root = utils.get_etree_root(doc)
 
         # Check that the root is a valid CybOX root-level element
-        check_root(doc)
-
-        # Get the CybOX document version number and attempt
-        version = version or get_version(doc)
-        check_version(version)
+        check_root(root)
 
         return func(*args, **kwargs)
 

--- a/sdv/validators/stix/best_practice.py
+++ b/sdv/validators/stix/best_practice.py
@@ -792,9 +792,19 @@ class STIXBestPracticeValidator(object):
             .ValidationError: If there are any issues parsing `doc`.
 
         """
+        # Get the element for the input document
         root = utils.get_etree_root(doc)
-        version = version or common.get_version(doc)
+
+        # Get the STIX version for the input `doc` if one is not passed in.
+        version = version or common.get_version(root)
+
+        # Check that the version number is a valid STIX version number
+        common.check_version(version)
+
+        # Run the best practice checks applicable for the STIX version number.
         results = self._run_rules(root, version)
+
+        # Return the results
         return results
 
 

--- a/sdv/validators/stix/common.py
+++ b/sdv/validators/stix/common.py
@@ -481,10 +481,8 @@ def check_root(doc):
 
 
 def check_stix(func):
-    """Decorator which checks that the input document is a STIX document
-    and that it contains a valid STIX version number.
+    """Decorator which checks that the input document is a STIX document."""
 
-    """
     @functools.wraps(func)
     def _check_stix(*args, **kwargs):
         try:
@@ -492,19 +490,11 @@ def check_stix(func):
         except IndexError:
             doc = kwargs['doc']
 
-        try:
-            version = args[2]
-        except IndexError:
-            version = kwargs.get('version')
-
-        doc = utils.get_etree_root(doc)
+        # Get the root element for the input doc
+        root = utils.get_etree_root(doc)
 
         # Check that the root is a valid STIX root-level element
-        check_root(doc)
-
-        # Get the STIX document version number and attempt
-        version = version or get_version(doc)
-        check_version(version)
+        check_root(root)
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
The version number requirements for validation changed between the v2.0.2 tag and the v2.1.0 branch. This PR reverts the version requirements and behavior back to v2.0.2.

* No version information is required by the API when validating against `@xsi:schemaLocation` or non-bundled schemas.
* STIX profile validation does not require version information to be passed in or declared in the document.
* Updated documentation to better explain when version information is required from the user/input and when it will be ignored.

Fixes #56 